### PR TITLE
fix: #849 Doubled memory for fhir servers

### DIFF
--- a/qa/fhir-server/deployments.yml
+++ b/qa/fhir-server/deployments.yml
@@ -18,6 +18,13 @@ spec:
       containers:
         - image: ferlabcrsj/clin-fhir-server:220bafb
           name: clin-fhir-server
+          resources:
+            requests:
+              memory: "2048Mi"
+              cpu: "1.00"
+            limits:
+              memory: "4096Mi"
+              cpu: "2.00"
           env:
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:


### PR DESCRIPTION
Doubled memory for fhir servers