### PR TITLE
fix: #425 Fixed wrong namespace for spark rolebinding

### DIFF
--- a/qa/spark-core/access.yml
+++ b/qa/spark-core/access.yml
@@ -30,4 +30,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: spark
-    namespace: spark
+    namespace: clin-qa


### PR DESCRIPTION
Fixed wrong namespace for spark rolebinding